### PR TITLE
add libasound2-dev dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
             - libxinerama-dev
             - libxcursor-dev
             - libxi-dev
+            - libasound2-dev
 go:
 - 1.8
 - 1.7.4


### PR DESCRIPTION
This should fix travis builds for the `audio` branch