### PR TITLE
pixel/pixelgl: export UpdateInput

### DIFF
--- a/pixelgl/input.go
+++ b/pixelgl/input.go
@@ -372,7 +372,9 @@ func (w *Window) initInput() {
 	})
 }
 
-func (w *Window) updateInput() {
+// UpdateInput polls window events. Call this function to poll window events
+// without swapping buffers. Note that the Update method invokes UpdateInput.
+func (w *Window) UpdateInput() {
 	mainthread.Call(func() {
 		glfw.PollEvents()
 	})

--- a/pixelgl/window.go
+++ b/pixelgl/window.go
@@ -190,7 +190,7 @@ func (w *Window) Update() {
 		w.end()
 	})
 
-	w.updateInput()
+	w.UpdateInput()
 }
 
 // SetClosed sets the closed flag of the Window.


### PR DESCRIPTION
This change mirrors the change done in the master branch
(see #78) for users of gl2.1, to provide access to polling
of events without rendering the screen.

Updates #26.