### PR TITLE
Adds video mode support and a community example for its usage.

### DIFF
--- a/examples/community/video-modes/README.md
+++ b/examples/community/video-modes/README.md
@@ -1,0 +1,12 @@
+# Video Modes
+
+Just a demo on how to retrieve and set video modes with Pixel.
+
+Made by [David Linus Briemann](https://github.com/dbriemann/).
+
+## Controls
+
+ESC - Quit
+W - Toggle between fullscreen and windowed.
+
+Switch video modes with the shown characters.

--- a/examples/community/video-modes/main.go
+++ b/examples/community/video-modes/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/faiface/pixel"
+	"github.com/faiface/pixel/pixelgl"
+	"github.com/faiface/pixel/text"
+	"golang.org/x/image/colornames"
+	"golang.org/x/image/font/basicfont"
+)
+
+var (
+	texts         []*text.Text
+	staticText    *text.Text
+	vmodes        []*pixelgl.VideoMode
+	activeMode    pixelgl.VideoMode
+	activeMonitor *pixelgl.Monitor
+)
+
+func run() {
+	cfg := pixelgl.WindowConfig{
+		Title:  "Video Modes",
+		Bounds: pixel.R(0, 0, 800, 600),
+	}
+	win, err := pixelgl.NewWindow(cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	atlas := text.NewAtlas(basicfont.Face7x13, text.ASCII)
+
+	// Retrieve all monitors.
+	monitors := pixelgl.Monitors()
+
+	texts = make([]*text.Text, len(monitors))
+	key := byte('0')
+	for i := 0; i < len(monitors); i++ {
+		// Retrieve all video modes for a specific monitor.
+		modes := monitors[i].VideoModes()
+
+		vmodes = append(vmodes, modes...)
+		texts[i] = text.New(pixel.V(10+250*float64(i), -20), atlas)
+		texts[i].Color = colornames.Black
+		texts[i].WriteString(fmt.Sprintf("MONITOR %s\n\n", monitors[i].Name()))
+
+		for _, v := range modes {
+			texts[i].WriteString(fmt.Sprintf("(%c) %dx%d @ %d hz, %d bpp\n", key, v.Width, v.Height, v.RefreshRate, v.BlueBits+v.RedBits+v.GreenBits))
+			key++
+		}
+	}
+
+	staticText = text.New(pixel.V(10, 30), atlas)
+	staticText.Color = colornames.Black
+	staticText.WriteString("ESC to exit\nW toggles windowed/fullscreen")
+
+	for !win.Closed() {
+		win.Clear(colornames.Antiquewhite)
+
+		for _, txt := range texts {
+			txt.Draw(win, pixel.IM.Moved(pixel.V(0, win.Bounds().H())))
+		}
+		staticText.Draw(win, pixel.IM)
+
+		if win.JustPressed(pixelgl.KeyEscape) {
+			win.SetClosed(true)
+		}
+
+		if win.JustPressed(pixelgl.KeyW) {
+			if activeMode.Monitor != nil {
+				// Switch to windowed and backup the correct monitor.
+				activeMonitor = activeMode.Monitor
+				activeMode.Monitor = nil
+				win.SetVideoMode(activeMode)
+			} else {
+				// Switch to fullscreen.
+				activeMode.Monitor = activeMonitor
+				win.SetVideoMode(activeMode)
+			}
+		}
+
+		input := win.Typed()
+		if len(input) > 0 {
+			key := int(input[0]) - 48
+			fmt.Println(key)
+			if key >= 0 && key < len(vmodes) {
+				activeMode = *vmodes[key]
+				activeMonitor = activeMode.Monitor
+				fmt.Println("change to:", activeMode.Width, activeMode.Height)
+				win.SetVideoMode(activeMode)
+			}
+		}
+
+		win.Update()
+	}
+}
+
+func main() {
+	pixelgl.Run(run)
+}

--- a/pixelgl/monitor.go
+++ b/pixelgl/monitor.go
@@ -10,13 +10,15 @@ type Monitor struct {
 	monitor *glfw.Monitor
 }
 
-// VideoMode represents all properties of a video mode and is attached
-// to a monitor if it is a fullscreen mode.
+// VideoMode represents all properties of a video mode and is
+// associated with a monitor if it is used in fullscreen mode.
 type VideoMode struct {
-	*glfw.VidMode
-	// Monitor is a pointer to the monitor that owns this video mode.
-	// If Monitor is nil the video mode is windowed.
-	Monitor *Monitor
+	// Width is the width of the vide mode in pixels.
+	Width int
+	// Height is the height of the video mode in pixels.
+	Height int
+	// RefreshRate holds the refresh rate of the associated monitor in Hz.
+	RefreshRate int
 }
 
 // PrimaryMonitor returns the main monitor (usually the one with the taskbar and stuff).
@@ -106,15 +108,16 @@ func (m *Monitor) RefreshRate() (rate float64) {
 }
 
 // VideoModes returns all available video modes for the monitor.
-func (m *Monitor) VideoModes() (vmodes []*VideoMode) {
+func (m *Monitor) VideoModes() (vmodes []VideoMode) {
 	var modes []*glfw.VidMode
 	mainthread.Call(func() {
 		modes = m.monitor.GetVideoModes()
 	})
 	for _, mode := range modes {
-		vmodes = append(vmodes, &VideoMode{
-			VidMode: mode,
-			Monitor: m,
+		vmodes = append(vmodes, VideoMode{
+			Width:       mode.Width,
+			Height:      mode.Height,
+			RefreshRate: mode.RefreshRate,
 		})
 	}
 	return

--- a/pixelgl/monitor.go
+++ b/pixelgl/monitor.go
@@ -10,6 +10,15 @@ type Monitor struct {
 	monitor *glfw.Monitor
 }
 
+// VideoMode represents all properties of a video mode and is attached
+// to a monitor if it is a fullscreen mode.
+type VideoMode struct {
+	*glfw.VidMode
+	// Monitor is a pointer to the monitor that owns this video mode.
+	// If Monitor is nil the video mode is windowed.
+	Monitor *Monitor
+}
+
 // PrimaryMonitor returns the main monitor (usually the one with the taskbar and stuff).
 func PrimaryMonitor() *Monitor {
 	var monitor *glfw.Monitor
@@ -93,5 +102,20 @@ func (m *Monitor) RefreshRate() (rate float64) {
 		mode = m.monitor.GetVideoMode()
 	})
 	rate = float64(mode.RefreshRate)
+	return
+}
+
+// VideoModes returns all available video modes for the monitor.
+func (m *Monitor) VideoModes() (vmodes []*VideoMode) {
+	var modes []*glfw.VidMode
+	mainthread.Call(func() {
+		modes = m.monitor.GetVideoModes()
+	})
+	for _, mode := range modes {
+		vmodes = append(vmodes, &VideoMode{
+			VidMode: mode,
+			Monitor: m,
+		})
+	}
 	return
 }

--- a/pixelgl/window.go
+++ b/pixelgl/window.go
@@ -424,3 +424,9 @@ func (w *Window) Clear(c color.Color) {
 func (w *Window) Color(at pixel.Vec) pixel.RGBA {
 	return w.canvas.Color(at)
 }
+
+// SetVideoMode applies the given video mode to this window.
+func (w *Window) SetVideoMode(vm VideoMode) {
+	w.SetMonitor(vm.Monitor)
+	w.SetBounds(pixel.R(0, 0, float64(vm.Width), float64(vm.Height)))
+}

--- a/pixelgl/window.go
+++ b/pixelgl/window.go
@@ -424,9 +424,3 @@ func (w *Window) Clear(c color.Color) {
 func (w *Window) Color(at pixel.Vec) pixel.RGBA {
 	return w.canvas.Color(at)
 }
-
-// SetVideoMode applies the given video mode to this window.
-func (w *Window) SetVideoMode(vm VideoMode) {
-	w.SetMonitor(vm.Monitor)
-	w.SetBounds(pixel.R(0, 0, float64(vm.Width), float64(vm.Height)))
-}


### PR DESCRIPTION
I added support for video modes as discussed in https://github.com/faiface/pixel/issues/113.
I also added a community example on how to use video modes.

Just tell me if there is something that should be done differently. I'm new to the project :)

I have not changed the API just extended it by two functions:
`func (w *Window) SetVideoMode(vm VideoMode)`, `func (m *Monitor) VideoModes() (vmodes []*VideoMode)` and a struct: `VideoMode`.
