### PR TITLE
CI support for example/amidakuji

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,18 @@ addons:
 go:
 - 1.8
 - 1.7.4
-- tip 
+- tip
+
+before_install:
+- echo "installing requirements for example/amidakuji"
+- sudo apt-get -qq install libpango1.0-dev libgtk2.0-dev
+- go get -v -u github.com/go-bindata/go-bindata/...
+- make glossary/asset.go --directory=$TRAVIS_BUILD_DIR/examples/community/amidakuji/
+- echo "end of before_install"
+
 install:
 - go get -t ./...
+
 script:
 - go test -i -race ./...
 - go test -v -race ./...
-


### PR DESCRIPTION
Update `.travis.yml` 
CI installs missing 3rd party dependencies that are only for `example/amidakuji`
