### PR TITLE
fix typo for matrix

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -310,7 +310,7 @@ func (r Rect) Intersect(s Rect) Rect {
 	return t
 }
 
-// Matrix is a 3x2 affine matrix that can be used for all kinds of spatial transforms, such
+// Matrix is a 2x3 affine matrix that can be used for all kinds of spatial transforms, such
 // as movement, scaling and rotations.
 //
 // Matrix has a handful of useful methods, each of which adds a transformation to the matrix. For


### PR DESCRIPTION
It's like very small typo in comment, that I wonder if anyone's ever going to notice xD

Comment says it's a 3x2 Matrix but it's actually a 2x3 Matrix according to Wiki page.

https://github.com/faiface/pixel/issues/115

https://github.com/faiface/pixel/wiki/Moving,-scaling-and-rotating-with-Matrix#matrix
