### PR TITLE
standardized glsl variable naming

### DIFF
--- a/pixelgl/canvas.go
+++ b/pixelgl/canvas.go
@@ -46,8 +46,8 @@ func NewCanvas(bounds pixel.Rect) *Canvas {
 // SetUniform will update the named uniform with the value of any supported underlying
 // attribute variable. If the uniform already exists, including defaults, they will be reassigned
 // to the new value. The value can be a pointer.
-func (c *Canvas) SetUniform(Name string, Value interface{}) {
-	c.shader.setUniform(Name, Value)
+func (c *Canvas) SetUniform(name string, value interface{}) {
+	c.shader.setUniform(name, value)
 }
 
 // SetFragmentShader allows you to set a new fragment shader on the underlying

--- a/pixelgl/canvas.go
+++ b/pixelgl/canvas.go
@@ -363,8 +363,8 @@ const (
 )
 
 var defaultCanvasVertexFormat = glhf.AttrFormat{
-	canvasPosition:  {Name: "position", Type: glhf.Vec2},
-	canvasColor:     {Name: "color", Type: glhf.Vec4},
-	canvasTexCoords: {Name: "texCoords", Type: glhf.Vec2},
-	canvasIntensity: {Name: "intensity", Type: glhf.Float},
+	canvasPosition:  {Name: "aPosition", Type: glhf.Vec2},
+	canvasColor:     {Name: "aColor", Type: glhf.Vec4},
+	canvasTexCoords: {Name: "aTexCoords", Type: glhf.Vec2},
+	canvasIntensity: {Name: "aIntensity", Type: glhf.Float},
 }


### PR DESCRIPTION
I wanted to get this done before going version 0.8

This PR is to standardize the GLSL variable naming we use. There is no one official standard however there are plenty of common defacto standards. I went with what I think is best overall:

Any variables going into the vertex shader are attributes; so any attribute variable should begin with a lowercase a. Example:
```
in vec2  aPosition;
in vec4  aColor;
in vec2  aTexCoords;
in float aIntensity;
```
Any variables being sent to the fragment shader from the vertex shader are varyings; so any varying variable should begin with a lowercase v. Example:
```
// Vertex Shader would use:
out vec4  vColor;
out vec2  vTexCoords;
out float vIntensity;

// Fragment Shader would use:
in vec4  vColor;
in vec2  vTexCoords;
in float vIntensity;
```

Any uniform variables being sent to either shader should begin with a lowercase u. Example:
```
uniform vec4      uColorMask;
uniform vec4      uTexBounds;
uniform sampler2D uTexture;
```