### PR TITLE
Added position as out variable from vertex shader.

### DIFF
--- a/pixelgl/glshader.go
+++ b/pixelgl/glshader.go
@@ -226,6 +226,7 @@ in float aIntensity;
 out vec4  vColor;
 out vec2  vTexCoords;
 out float vIntensity;
+out vec2  vPosition;
 
 uniform mat3 uTransform;
 uniform vec4 uBounds;
@@ -235,6 +236,7 @@ void main() {
 	vec2 normPos = (transPos - uBounds.xy) / uBounds.zw * 2 - vec2(1, 1);
 	gl_Position = vec4(normPos, 0.0, 1.0);
 	vColor = aColor;
+	vPosition = aPosition;
 	vTexCoords = aTexCoords;
 	vIntensity = aIntensity;
 }


### PR DESCRIPTION
Adding the position out from vertex shader makes us skip computation of position in the fragment shader based on gl_FragCoord.

This is needed if creating fragment shaders based on some uniform positions for distance calculations like below.

float distance = sqrt(pow(vPosition.x-uPos.x, 2) + pow(vPosition.y-uPos.y, 2))

If we don't provide vPosition I think we need the screen resolution as uniforms to the fragment shader in order to calculate the position based on gl_FragCoord. Correct me if I'm wrong!