### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/pixelgl/input.go
+++ b/pixelgl/input.go
@@ -54,7 +54,7 @@ func (w *Window) SetMousePosition(v pixel.Vec) {
 	})
 }
 
-// MouseEntered returns true if the mouse position is within the Window's Bounds.
+// MouseInsideWindow returns true if the mouse position is within the Window's Bounds.
 func (w *Window) MouseInsideWindow() bool {
 	return w.cursorInsideWindow
 }


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?