### PR TITLE
Setting position in correct order

### DIFF
--- a/sprite.go
+++ b/sprite.go
@@ -102,10 +102,10 @@ func (s *Sprite) calcData() {
 	(*s.tri)[5].Position = Vec{}.Sub(horizontal).Add(vertical)
 
 	for i := range *s.tri {
-		(*s.tri)[i].Position = s.matrix.Project((*s.tri)[i].Position)
 		(*s.tri)[i].Color = s.mask
 		(*s.tri)[i].Picture = center.Add((*s.tri)[i].Position)
 		(*s.tri)[i].Intensity = 1
+		(*s.tri)[i].Position = s.matrix.Project((*s.tri)[i].Position)
 	}
 
 	s.d.Dirty()


### PR DESCRIPTION
Looks like #177 broke the sprite positioning because of [this line](https://github.com/faiface/pixel/blob/master/sprite.go#L107) using `.Position`, but expected position to be changed in the loop *afterwards*

Resolves #180 