### PR TITLE
Added TriangleData benchmarks and improvements

### DIFF
--- a/data.go
+++ b/data.go
@@ -50,15 +50,10 @@ func (td *TrianglesData) Len() int {
 // values ((0, 0), white, (0, 0), 0).
 func (td *TrianglesData) SetLen(len int) {
 	if len > td.Len() {
-		newTD := make(TrianglesData, len)
-		copy(newTD, *td)
-
 		needAppend := len - td.Len()
-		for i := td.Len(); i < needAppend; i++ {
-			newTD[i] = zeroValueTriangleData
+		for i := 0; i < needAppend; i++ {
+			*td = append(*td, zeroValueTriangleData)
 		}
-
-		*td = newTD
 	}
 	if len < td.Len() {
 		*td = (*td)[:len]

--- a/data.go
+++ b/data.go
@@ -8,6 +8,16 @@ import (
 	"math"
 )
 
+var (
+	// zeroValueTriangleData is the default value of a TriangleData element
+	zeroValueTriangleData = struct {
+		Position  Vec
+		Color     RGBA
+		Picture   Vec
+		Intensity float64
+	}{Color: RGBA{1, 1, 1, 1}}
+)
+
 // TrianglesData specifies a list of Triangles vertices with three common properties:
 // TrianglesPosition, TrianglesColor and TrianglesPicture.
 type TrianglesData []struct {
@@ -22,9 +32,11 @@ type TrianglesData []struct {
 // Prefer this function to make(TrianglesData, len), because make zeros them, while this function
 // does the correct intialization.
 func MakeTrianglesData(len int) *TrianglesData {
-	td := &TrianglesData{}
-	td.SetLen(len)
-	return td
+	td := make(TrianglesData, len)
+	for i := 0; i < len; i++ {
+		td[i] = zeroValueTriangleData
+	}
+	return &td
 }
 
 // Len returns the number of vertices in TrianglesData.
@@ -38,15 +50,15 @@ func (td *TrianglesData) Len() int {
 // values ((0, 0), white, (0, 0), 0).
 func (td *TrianglesData) SetLen(len int) {
 	if len > td.Len() {
+		newTD := make(TrianglesData, len)
+		copy(newTD, *td)
+
 		needAppend := len - td.Len()
-		for i := 0; i < needAppend; i++ {
-			*td = append(*td, struct {
-				Position  Vec
-				Color     RGBA
-				Picture   Vec
-				Intensity float64
-			}{Color: RGBA{1, 1, 1, 1}})
+		for i := td.Len(); i < needAppend; i++ {
+			newTD[i] = zeroValueTriangleData
 		}
+
+		*td = newTD
 	}
 	if len < td.Len() {
 		*td = (*td)[:len]
@@ -96,10 +108,9 @@ func (td *TrianglesData) Update(t Triangles) {
 
 // Copy returns an exact independent copy of this TrianglesData.
 func (td *TrianglesData) Copy() Triangles {
-	copyTd := TrianglesData{}
-	copyTd.SetLen(td.Len())
+	copyTd := MakeTrianglesData(td.Len())
 	copyTd.Update(td)
-	return &copyTd
+	return copyTd
 }
 
 // Position returns the position property of i-th vertex.

--- a/data_test.go
+++ b/data_test.go
@@ -6,6 +6,30 @@ import (
 	"github.com/faiface/pixel"
 )
 
+func BenchmarkMakeTrianglesData(b *testing.B) {
+	tests := []struct {
+		name string
+		len  int
+	}{
+		{
+			name: "Small slice",
+			len:  10,
+		},
+		{
+			name: "Large slice",
+			len:  10000,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = pixel.MakeTrianglesData(tt.len)
+			}
+		})
+	}
+}
+
 func BenchmarkTrianglesData_Len(b *testing.B) {
 	tests := []struct {
 		name  string

--- a/data_test.go
+++ b/data_test.go
@@ -1,0 +1,244 @@
+package pixel_test
+
+import (
+	"testing"
+
+	"github.com/faiface/pixel"
+)
+
+func BenchmarkTrianglesData_Len(b *testing.B) {
+	tests := []struct {
+		name  string
+		tData *pixel.TrianglesData
+	}{
+		{
+			name:  "Small slice",
+			tData: pixel.MakeTrianglesData(10),
+		},
+		{
+			name:  "Large slice",
+			tData: pixel.MakeTrianglesData(10000),
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = tt.tData.Len()
+			}
+		})
+	}
+}
+
+func BenchmarkTrianglesData_SetLen(b *testing.B) {
+	tests := []struct {
+		name        string
+		tData       *pixel.TrianglesData
+		nextLenFunc func(int, int) (int, int)
+	}{
+		{
+			name:        "Stay same size",
+			tData:       pixel.MakeTrianglesData(50),
+			nextLenFunc: func(i, j int) (int, int) { return 50, 0 },
+		},
+		{
+			name:  "Change size",
+			tData: pixel.MakeTrianglesData(50),
+			nextLenFunc: func(i, j int) (int, int) {
+				// 0 is shrink
+				if j == 0 {
+					next := i - 1
+					if next < 1 {
+						return 2, 1
+					}
+					return next, 0
+				}
+
+				// other than 0 is grow
+				next := i + 1
+				if next == 100 {
+					return next, 0
+				}
+				return next, 1
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			var newLen int
+			var c int
+			for i := 0; i < b.N; i++ {
+				newLen, c = tt.nextLenFunc(newLen, c)
+				tt.tData.SetLen(newLen)
+			}
+		})
+	}
+}
+
+func BenchmarkTrianglesData_Slice(b *testing.B) {
+	tests := []struct {
+		name  string
+		tData *pixel.TrianglesData
+	}{
+		{
+			name:  "Basic slice",
+			tData: pixel.MakeTrianglesData(100),
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = tt.tData.Slice(25, 50)
+			}
+		})
+	}
+}
+
+func BenchmarkTrianglesData_Update(b *testing.B) {
+	tests := []struct {
+		name  string
+		tData *pixel.TrianglesData
+		t     pixel.Triangles
+	}{
+		{
+			name:  "Small Triangles",
+			tData: pixel.MakeTrianglesData(20),
+			t:     pixel.MakeTrianglesData(20),
+		},
+		{
+			name:  "Large Triangles",
+			tData: pixel.MakeTrianglesData(10000),
+			t:     pixel.MakeTrianglesData(10000),
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				tt.tData.Update(tt.t)
+			}
+		})
+	}
+}
+
+func BenchmarkTrianglesData_Copy(b *testing.B) {
+	tests := []struct {
+		name  string
+		tData *pixel.TrianglesData
+	}{
+		{
+			name:  "Small copy",
+			tData: pixel.MakeTrianglesData(20),
+		},
+		{
+			name:  "Large copy",
+			tData: pixel.MakeTrianglesData(10000),
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = tt.tData.Copy()
+			}
+		})
+	}
+}
+
+func BenchmarkTrianglesData_Position(b *testing.B) {
+	tests := []struct {
+		name     string
+		tData    *pixel.TrianglesData
+		position int
+	}{
+		{
+			name:     "Getting beginning position",
+			tData:    pixel.MakeTrianglesData(1000),
+			position: 2,
+		},
+		{
+			name:     "Getting middle position",
+			tData:    pixel.MakeTrianglesData(1000),
+			position: 500,
+		},
+		{
+			name:     "Getting end position",
+			tData:    pixel.MakeTrianglesData(1000),
+			position: 999,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = tt.tData.Position(tt.position)
+			}
+		})
+	}
+}
+
+func BenchmarkTrianglesData_Color(b *testing.B) {
+	tests := []struct {
+		name     string
+		tData    *pixel.TrianglesData
+		position int
+	}{
+		{
+			name:     "Getting beginning position",
+			tData:    pixel.MakeTrianglesData(1000),
+			position: 2,
+		},
+		{
+			name:     "Getting middle position",
+			tData:    pixel.MakeTrianglesData(1000),
+			position: 500,
+		},
+		{
+			name:     "Getting end position",
+			tData:    pixel.MakeTrianglesData(1000),
+			position: 999,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = tt.tData.Color(tt.position)
+			}
+		})
+	}
+}
+
+func BenchmarkTrianglesData_Picture(b *testing.B) {
+	tests := []struct {
+		name     string
+		tData    *pixel.TrianglesData
+		position int
+	}{
+		{
+			name:     "Getting beginning position",
+			tData:    pixel.MakeTrianglesData(1000),
+			position: 2,
+		},
+		{
+			name:     "Getting middle position",
+			tData:    pixel.MakeTrianglesData(1000),
+			position: 500,
+		},
+		{
+			name:     "Getting end position",
+			tData:    pixel.MakeTrianglesData(1000),
+			position: 999,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = tt.tData.Picture(tt.position)
+			}
+		})
+	}
+}


### PR DESCRIPTION
~~**Raising as draft as I haven't had time to fully test this hasn't broken things. I'll mark as ready when I've checked some examples, etc**~~

Starting to address #46 - thought it'd be too big for one go.  This PR adds benchmarks for all exported methods of `pixel.TriangleData`, I've gone for the "low hanging fruit" and trimmed off a decent amount of heap allocation, and sped some of the more heavily used functions.

These are the benchmarks on the code unaltered:
```goos: linux
goarch: amd64
pkg: github.com/faiface/pixel
BenchmarkMakeTrianglesData/Small_slice-24         	 1000000	      1518 ns/op	    2240 B/op	       5 allocs/op
BenchmarkMakeTrianglesData/Large_slice-24         	    1000	   1779970 ns/op	 4086468 B/op	      21 allocs/op
BenchmarkTrianglesData_Len/Small_slice-24         	2000000000	         0.74 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Len/Large_slice-24         	2000000000	         0.78 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_SetLen/Stay_same_size-24   	200000000	         7.53 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_SetLen/Change_size-24      	100000000	        11.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Slice/Basic_slice-24       	2000000000	         0.80 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Update/Small_Triangles-24  	20000000	        59.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Update/Large_Triangles-24  	   30000	     57695 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Copy/Small_copy-24         	 1000000	      3478 ns/op	    4576 B/op	       7 allocs/op
BenchmarkTrianglesData_Copy/Large_copy-24         	    1000	   1821426 ns/op	 4086500 B/op	      22 allocs/op
BenchmarkTrianglesData_Position/Getting_beginning_position-24         	2000000000	         0.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Position/Getting_middle_position-24            	2000000000	         0.78 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Position/Getting_end_position-24               	2000000000	         0.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Color/Getting_beginning_position-24            	2000000000	         0.79 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Color/Getting_middle_position-24               	2000000000	         0.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Color/Getting_end_position-24                  	2000000000	         0.75 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Picture/Getting_beginning_position-24          	2000000000	         0.78 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Picture/Getting_middle_position-24             	2000000000	         0.77 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Picture/Getting_end_position-24                	2000000000	         0.76 ns/op	       0 B/op	       0 allocs/op
PASS
```

Benchmarks after these PR changes:
```goos: linux
goarch: amd64
pkg: github.com/faiface/pixel
BenchmarkMakeTrianglesData/Small_slice-24         	 3000000	       498 ns/op	     800 B/op	       2 allocs/op
BenchmarkMakeTrianglesData/Large_slice-24         	    5000	    286247 ns/op	  720928 B/op	       2 allocs/op
BenchmarkTrianglesData_Len/Small_slice-24         	2000000000	         0.77 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Len/Large_slice-24         	2000000000	         0.74 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_SetLen/Stay_same_size-24   	200000000	         7.15 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_SetLen/Change_size-24      	 2000000	       989 ns/op	    1954 B/op	       0 allocs/op
BenchmarkTrianglesData_Slice/Basic_slice-24       	2000000000	         0.79 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Update/Small_Triangles-24  	20000000	        52.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Update/Large_Triangles-24  	   30000	     50046 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Copy/Small_copy-24         	 1000000	      1257 ns/op	    1568 B/op	       2 allocs/op
BenchmarkTrianglesData_Copy/Large_copy-24         	    3000	    400064 ns/op	  720929 B/op	       2 allocs/op
BenchmarkTrianglesData_Position/Getting_beginning_position-24         	2000000000	         0.76 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Position/Getting_middle_position-24            	2000000000	         0.71 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Position/Getting_end_position-24               	2000000000	         0.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Color/Getting_beginning_position-24            	2000000000	         0.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Color/Getting_middle_position-24               	2000000000	         0.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Color/Getting_end_position-24                  	2000000000	         0.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Picture/Getting_beginning_position-24          	2000000000	         0.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Picture/Getting_middle_position-24             	2000000000	         0.69 ns/op	       0 B/op	       0 allocs/op
BenchmarkTrianglesData_Picture/Getting_end_position-24                	2000000000	         0.76 ns/op	       0 B/op	       0 allocs/op
PASS
```

---

Improvements to  note:
`MakeTrianglesData()` for slice of 10,000 reduced op-time by ~1.5ms (~16% original time)
`TriangleData.Update()` for slice of 10,000 reduced op-time by ~7000ns (~86% original time)
`TriangleData.Copy()` for slice of 20 reduced op time by >2000ns (~36% original time).
`TriangleData.Copy()` for slice of 10,000 reduced op-time by ~1.4ms (~21% original time)
`TriangleData.Copy()` for slice of 10,000 reduced allocations per op by 20 (~9% original allocs per op)

This does not resolve the issue, and does not attempt to implement the suggested new interface.  Until there are benchmarks, we won't know whether speed is improving; this PR is intended as a stepping stone.