### PR TITLE
Adding AutoIconify and Floating GLFW window hints

### DIFF
--- a/pixelgl/window.go
+++ b/pixelgl/window.go
@@ -46,6 +46,16 @@ type WindowConfig struct {
 	// Undecorated Window ommits the borders and decorations (close button, etc.).
 	Undecorated bool
 
+	// NoIconify specifies whether fullscreen windows should not automatically
+	// iconify (and restore the previous video mode) on focus loss.
+	NoIconify bool
+
+	// AlwaysOnTop specifies whether the windowed mode window will be floating
+	// above other regular windows, also called topmost or always-on-top.
+	// This is intended primarily for debugging purposes and cannot be used to
+	// implement proper full screen windows.
+	AlwaysOnTop bool
+
 	// VSync (vertical synchronization) synchronizes Window's framerate with the framerate of
 	// the monitor.
 	VSync bool
@@ -100,6 +110,8 @@ func NewWindow(cfg WindowConfig) (*Window, error) {
 
 		glfw.WindowHint(glfw.Resizable, bool2int[cfg.Resizable])
 		glfw.WindowHint(glfw.Decorated, bool2int[!cfg.Undecorated])
+		glfw.WindowHint(glfw.Floating, bool2int[cfg.AlwaysOnTop])
+		glfw.WindowHint(glfw.AutoIconify, bool2int[!cfg.NoIconify])
 
 		var share *glfw.Window
 		if currWin != nil {


### PR DESCRIPTION
I want to create a non-full screen application that must display information on top of all other windows. This is supported in GLFW via the [`Floating` constant][1] which can be set via `glfw.WindowHint(…)`.

To support this feature I added a boolean `Floating` field to the `pixelgl.WindowConfig` type which is then used when setting up the window in `pixelgl.NewWindow()`. I then also saw there is an option to automatically add a preview for the window when I switch between applications so I added that as well in the same way (using `glfw.AutoIconify`).

I wasn't sure if and how I could write tests for those two fields. Also adding an example in that other repo didn't seem applicable here but let me know if there is anything more you would like me to do or change :)

[1]: https://github.com/go-gl/glfw/blob/e6da0acd62b1b57ee2799d4d0a76a7d4514dc5bc/v3.2/glfw/window.go#L62