### PR TITLE
Fix Go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,7 @@ services:
 
 go:
     - tip
-    - 1.8.x
-    - 1.7.4
-
-install:
-    - go get -t ./...
+    - 1.12.x
 
 script:
-    - go test -i -race ./...
-    - go test -v -race ./...
+    - go test -v -race -mod=readonly ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,10 @@ go:
     - tip
     - 1.12.x
 
+install:
+    - # Do nothing. This is needed to prevent the default install action
+      # "go get -t -v ./..." from happening here because we want it to happen
+      # inside script step.
+
 script:
     - go test -v -race -mod=readonly ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ addons:
 services:
     - xvfb
 
+env:
+    - GO111MODULE=on
+
 go:
     - tip
     - 1.12.x

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ go get github.com/faiface/pixel
 If you are using Modules (Go 1.11 or higher) and want a mutable copy of the source code:
 
 ```
-git clone https://github.com/faiface/pixel ;# clone outside of GOPATH
+git clone https://github.com/faiface/pixel # clone outside of $GOPATH
 cd pixel
 go install ./...
 ```

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7 // indirect
 	github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1
 	github.com/go-gl/mathgl v0.0.0-20190416160123-c4601bc793c7
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/image v0.0.0-20190523035834-f03afa92d3ff

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1 h1:QbL/5oDUmRBzO9/Z7Seo
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/mathgl v0.0.0-20190416160123-c4601bc793c7 h1:THttjeRn1iiz69E875U6gAik8KTWk/JYAHoSVpUxBBI=
 github.com/go-gl/mathgl v0.0.0-20190416160123-c4601bc793c7/go.mod h1:yhpkQzEiH9yPyxDUGzkmgScbaBVlhC06qodikEM0ZwQ=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This is a follow up on #185 and #189 

I noticed that running `go test ./...` yielded a change of the `go.mod` file which comes from a missing test dependency:

```
$ go mod why -m github.com/golang/freetype
# github.com/golang/freetype
github.com/faiface/pixel/text
github.com/faiface/pixel/text.test
github.com/golang/freetype/truetype
```

See also this part of the Go wiki: https://github.com/golang/go/wiki/Modules#why-does-go-mod-tidy-record-indirect-and-test-dependencies-in-my-gomod

To avoid such issues in the future I changed the `.travis.yml` to use the go modules during testing as well (which is nice for reproducible builds) and to fail if a dependency is missing from the `go.mod` file.

You can see a successful build here: https://travis-ci.org/fgrosse/pixel/builds/539207777