### PR TITLE
Support glfw.TransparentFramebuffer window hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 - Gamepad API?
+- Add `WindowConfig.TransparentFramebuffer` option to support window transparency onto the background
 
 ## [v0.10.0-alpha] 2020-05-08
 - Upgrade to GLFW 3.3! :tada:

--- a/pixelgl/window.go
+++ b/pixelgl/window.go
@@ -56,6 +56,12 @@ type WindowConfig struct {
 	// implement proper full screen windows.
 	AlwaysOnTop bool
 
+	// TransparentFramebuffer specifies whether the window framebuffer will be
+	// transparent. If enabled and supported by the system, the window
+	// framebuffer alpha channel will be used to combine the framebuffer with
+	// the background. This does not affect window decorations.
+	TransparentFramebuffer bool
+
 	// VSync (vertical synchronization) synchronizes Window's framerate with the framerate of
 	// the monitor.
 	VSync bool
@@ -112,6 +118,7 @@ func NewWindow(cfg WindowConfig) (*Window, error) {
 		glfw.WindowHint(glfw.Decorated, bool2int[!cfg.Undecorated])
 		glfw.WindowHint(glfw.Floating, bool2int[cfg.AlwaysOnTop])
 		glfw.WindowHint(glfw.AutoIconify, bool2int[!cfg.NoIconify])
+		glfw.WindowHint(glfw.TransparentFramebuffer, bool2int[cfg.TransparentFramebuffer])
 
 		var share *glfw.Window
 		if currWin != nil {


### PR DESCRIPTION
Now that we have GLFW 3.3, we can use the `TransparentFramebuffer` window hint. This allows us to render windows which display transparent content so we can see other applications "through" it.

> GLFW_TRANSPARENT_FRAMEBUFFER specifies whether the window framebuffer will be transparent. If enabled and supported by the system, the window framebuffer alpha channel will be used to combine the framebuffer with the background. This does not affect window decorations. 

https://www.glfw.org/docs/3.3/window_guide.html#window_hints_wnd