### PR TITLE
Support setting an initial window position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 - Gamepad API?
+- Support setting an initial window position
 
 ## [v0.10.0-alpha] 2020-05-08
 - Upgrade to GLFW 3.3! :tada:

--- a/pixelgl/window.go
+++ b/pixelgl/window.go
@@ -36,6 +36,9 @@ type WindowConfig struct {
 	// Bounds specify the bounds of the Window in pixels.
 	Bounds pixel.Rect
 
+	// Initial window position
+	Position pixel.Vec
+
 	// If set to nil, the Window will be windowed. Otherwise it will be fullscreen on the
 	// specified Monitor.
 	Monitor *Monitor
@@ -113,6 +116,10 @@ func NewWindow(cfg WindowConfig) (*Window, error) {
 		glfw.WindowHint(glfw.Floating, bool2int[cfg.AlwaysOnTop])
 		glfw.WindowHint(glfw.AutoIconify, bool2int[!cfg.NoIconify])
 
+		if cfg.Position.X != 0 || cfg.Position.Y != 0 {
+			glfw.WindowHint(glfw.Visible, glfw.False)
+		}
+
 		var share *glfw.Window
 		if currWin != nil {
 			share = currWin.window
@@ -127,6 +134,11 @@ func NewWindow(cfg WindowConfig) (*Window, error) {
 		)
 		if err != nil {
 			return err
+		}
+
+		if cfg.Position.X != 0 || cfg.Position.Y != 0 {
+			w.window.SetPos(int(cfg.Position.X), int(cfg.Position.Y))
+			w.window.Show()
 		}
 
 		// enter the OpenGL context


### PR DESCRIPTION
This change allows users to specify the initial window position when they create the window. The advantage over calling `Window.SetPos(…)` after the window was created is, that the user will not see the window jump upon startup but it will directly spawn where we want it.

The method of marking the window at invisible is the suggested solution that is documented at [`glsw.CreateWindow(…)`][1]:

> To create the window at a specific position, make it initially invisible using the Visible window hint, set its position and then show it.

[1]: https://pkg.go.dev/github.com/go-gl/glfw@v0.0.0-20200420212212-258d9bec320e/v3.2/glfw?tab=doc#CreateWindow