### PR TITLE
Fixing line intersection for lines through origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 - Gamepad API?
+- Fixed Line intersects failing on lines passing through (0, 0)
 
 ## [v0.10.0-alpha] 2020-05-08
 - Upgrade to GLFW 3.3! :tada:

--- a/geometry.go
+++ b/geometry.go
@@ -406,12 +406,12 @@ func (l Line) IntersectRect(r Rect) Vec {
 			//  - the point is contained by the rectangle
 			//  - the point is not the corner itself
 			corners := r.Vertices()
-			closest := ZV
+			var closest *Vec
 			closestCorner := corners[0]
 			for _, c := range corners {
 				cc := l.Closest(c)
-				if closest == ZV || (closest.Len() > cc.Len() && r.Contains(cc)) {
-					closest = cc
+				if closest == nil || (closest.Len() > cc.Len() && r.Contains(cc)) {
+					closest = &cc
 					closestCorner = c
 				}
 			}

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -1002,6 +1002,18 @@ func TestLine_Closest(t *testing.T) {
 			args:   args{v: pixel.V(20, 20)},
 			want:   pixel.V(10, 10),
 		},
+		{
+			name:   "Vertical line",
+			fields: fields{A: pixel.V(0, -10), B: pixel.V(0, 10)},
+			args:   args{v: pixel.V(-1, 0)},
+			want:   pixel.V(0, 0),
+		},
+		{
+			name:   "Horizontal line",
+			fields: fields{A: pixel.V(-10, 0), B: pixel.V(10, 0)},
+			args:   args{v: pixel.V(0, -1)},
+			want:   pixel.V(0, 0),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1267,35 +1279,41 @@ func TestLine_IntersectRect(t *testing.T) {
 		args   args
 		want   pixel.Vec
 	}{
+		//{
+		//	name:   "Line through rect vertically",
+		//	fields: fields{A: pixel.V(0, 0), B: pixel.V(0, 10)},
+		//	args:   args{r: pixel.R(-1, 1, 5, 5)},
+		//	want:   pixel.V(-1, 0),
+		//},
+		//{
+		//	name:   "Line through rect horizontally",
+		//	fields: fields{A: pixel.V(0, 1), B: pixel.V(10, 1)},
+		//	args:   args{r: pixel.R(1, 0, 5, 5)},
+		//	want:   pixel.V(0, -1),
+		//},
+		//{
+		//	name:   "Line through rect diagonally bottom and left edges",
+		//	fields: fields{A: pixel.V(0, 0), B: pixel.V(10, 10)},
+		//	args:   args{r: pixel.R(0, 2, 3, 3)},
+		//	want:   pixel.V(-1, 1),
+		//},
+		//{
+		//	name:   "Line through rect diagonally top and right edges",
+		//	fields: fields{A: pixel.V(10, 0), B: pixel.V(0, 10)},
+		//	args:   args{r: pixel.R(5, 0, 8, 3)},
+		//	want:   pixel.V(-2.5, -2.5),
+		//},
+		//{
+		//	name:   "Line with not rect intersect",
+		//	fields: fields{A: pixel.V(0, 0), B: pixel.V(10, 10)},
+		//	args:   args{r: pixel.R(20, 20, 21, 21)},
+		//	want:   pixel.ZV,
+		//},
 		{
-			name:   "Line through rect vertically",
-			fields: fields{A: pixel.V(0, 0), B: pixel.V(0, 10)},
-			args:   args{r: pixel.R(-1, 1, 5, 5)},
+			name:   "Line intersects at 0,0",
+			fields: fields{A: pixel.V(0, -10), B: pixel.V(0, 10)},
+			args:   args{r: pixel.R(-1, 0, 2, 2)},
 			want:   pixel.V(-1, 0),
-		},
-		{
-			name:   "Line through rect horizontally",
-			fields: fields{A: pixel.V(0, 1), B: pixel.V(10, 1)},
-			args:   args{r: pixel.R(1, 0, 5, 5)},
-			want:   pixel.V(0, -1),
-		},
-		{
-			name:   "Line through rect diagonally bottom and left edges",
-			fields: fields{A: pixel.V(0, 0), B: pixel.V(10, 10)},
-			args:   args{r: pixel.R(0, 2, 3, 3)},
-			want:   pixel.V(-1, 1),
-		},
-		{
-			name:   "Line through rect diagonally top and right edges",
-			fields: fields{A: pixel.V(10, 0), B: pixel.V(0, 10)},
-			args:   args{r: pixel.R(5, 0, 8, 3)},
-			want:   pixel.V(-2.5, -2.5),
-		},
-		{
-			name:   "Line with not rect intersect",
-			fields: fields{A: pixel.V(0, 0), B: pixel.V(10, 10)},
-			args:   args{r: pixel.R(20, 20, 21, 21)},
-			want:   pixel.ZV,
 		},
 	}
 	for _, tt := range tests {

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -1279,36 +1279,36 @@ func TestLine_IntersectRect(t *testing.T) {
 		args   args
 		want   pixel.Vec
 	}{
-		//{
-		//	name:   "Line through rect vertically",
-		//	fields: fields{A: pixel.V(0, 0), B: pixel.V(0, 10)},
-		//	args:   args{r: pixel.R(-1, 1, 5, 5)},
-		//	want:   pixel.V(-1, 0),
-		//},
-		//{
-		//	name:   "Line through rect horizontally",
-		//	fields: fields{A: pixel.V(0, 1), B: pixel.V(10, 1)},
-		//	args:   args{r: pixel.R(1, 0, 5, 5)},
-		//	want:   pixel.V(0, -1),
-		//},
-		//{
-		//	name:   "Line through rect diagonally bottom and left edges",
-		//	fields: fields{A: pixel.V(0, 0), B: pixel.V(10, 10)},
-		//	args:   args{r: pixel.R(0, 2, 3, 3)},
-		//	want:   pixel.V(-1, 1),
-		//},
-		//{
-		//	name:   "Line through rect diagonally top and right edges",
-		//	fields: fields{A: pixel.V(10, 0), B: pixel.V(0, 10)},
-		//	args:   args{r: pixel.R(5, 0, 8, 3)},
-		//	want:   pixel.V(-2.5, -2.5),
-		//},
-		//{
-		//	name:   "Line with not rect intersect",
-		//	fields: fields{A: pixel.V(0, 0), B: pixel.V(10, 10)},
-		//	args:   args{r: pixel.R(20, 20, 21, 21)},
-		//	want:   pixel.ZV,
-		//},
+		{
+			name:   "Line through rect vertically",
+			fields: fields{A: pixel.V(0, 0), B: pixel.V(0, 10)},
+			args:   args{r: pixel.R(-1, 1, 5, 5)},
+			want:   pixel.V(-1, 0),
+		},
+		{
+			name:   "Line through rect horizontally",
+			fields: fields{A: pixel.V(0, 1), B: pixel.V(10, 1)},
+			args:   args{r: pixel.R(1, 0, 5, 5)},
+			want:   pixel.V(0, -1),
+		},
+		{
+			name:   "Line through rect diagonally bottom and left edges",
+			fields: fields{A: pixel.V(0, 0), B: pixel.V(10, 10)},
+			args:   args{r: pixel.R(0, 2, 3, 3)},
+			want:   pixel.V(-1, 1),
+		},
+		{
+			name:   "Line through rect diagonally top and right edges",
+			fields: fields{A: pixel.V(10, 0), B: pixel.V(0, 10)},
+			args:   args{r: pixel.R(5, 0, 8, 3)},
+			want:   pixel.V(-2.5, -2.5),
+		},
+		{
+			name:   "Line with not rect intersect",
+			fields: fields{A: pixel.V(0, 0), B: pixel.V(10, 10)},
+			args:   args{r: pixel.R(20, 20, 21, 21)},
+			want:   pixel.ZV,
+		},
 		{
 			name:   "Line intersects at 0,0",
 			fields: fields{A: pixel.V(0, -10), B: pixel.V(0, 10)},


### PR DESCRIPTION
Resolves #210 

## Description
The issue was that the algorithm which gets the closest corner of a `Rect` to a point on the line did not account for that point being ZV, so always ignored it.  The algorithm now uses a pointer to ensure every closest vector is valid.

## Changes
 - Added tests to the closest point function to confirm vertical and horizontal lines work fine
 - Added test as proposed in the issue to confirm the bug is fixed
 - Replaced zero vector as the initial closest value with a pointer
 - Updated change log