### PR TITLE
expose glfw.WaitEvent using Window.WaitInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support setting an initial window position
 - Support hiding the window initially
 - Support creating maximized windows
+- Support waiting for events to reduce CPU load
 
 ## [v0.10.0-beta] 2020-05-10
 - Add `WindowConfig.TransparentFramebuffer` option to support window transparency onto the background

--- a/pixelgl/input.go
+++ b/pixelgl/input.go
@@ -413,11 +413,11 @@ func (w *Window) UpdateInput() {
 	w.doUpdateInput()
 }
 
-// WaitInput blocks until an event is received or a timeout. If timeout is 0
+// UpdateInputWait blocks until an event is received or a timeout. If timeout is 0
 // then it will wait indefinitely
-func (w *Window) WaitInput(timeout time.Duration) {
+func (w *Window) UpdateInputWait(timeout time.Duration) {
 	mainthread.Call(func() {
-		if timeout == 0 {
+		if timeout <= 0 {
 			glfw.WaitEvents()
 		} else {
 			glfw.WaitEventsTimeout(timeout.Seconds())

--- a/pixelgl/input.go
+++ b/pixelgl/input.go
@@ -1,6 +1,8 @@
 package pixelgl
 
 import (
+	"time"
+
 	"github.com/faiface/mainthread"
 	"github.com/faiface/pixel"
 	"github.com/go-gl/glfw/v3.3/glfw"
@@ -408,7 +410,24 @@ func (w *Window) UpdateInput() {
 	mainthread.Call(func() {
 		glfw.PollEvents()
 	})
+	w.doUpdateInput()
+}
 
+// WaitInput blocks until an event is received or a timeout. If timeout is 0
+// then it will wait indefinitely
+func (w *Window) WaitInput(timeout time.Duration) {
+	mainthread.Call(func() {
+		if timeout == 0 {
+			glfw.WaitEvents()
+		} else {
+			glfw.WaitEventsTimeout(timeout.Seconds())
+		}
+	})
+	w.doUpdateInput()
+}
+
+// internal input bookkeeping
+func (w *Window) doUpdateInput() {
 	w.prevInp = w.currInp
 	w.currInp = w.tempInp
 


### PR DESCRIPTION
By using glfw.WaitEvent/WaitEventTimeout CPU time falls drastically (at the cost of less FPS). As the UI will be updated only when the OS notices that an event should be dispatched.

With this change users of pixel can choose between high FPS (window.UpdateInput) vs low FPS (window.WaitInput).