### PR TITLE
Adding Clipping rectangle support in GLTriangles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support hiding the window initially
 - Support creating maximized windows
 - Support waiting for events to reduce CPU load
+- Adding clipping rectangle support in GLTriangles
 
 ## [v0.10.0-beta] 2020-05-10
 - Add `WindowConfig.TransparentFramebuffer` option to support window transparency onto the background

--- a/pixelgl/canvas.go
+++ b/pixelgl/canvas.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"image/color"
 
+	"github.com/go-gl/gl/v3.3-core/gl"
+
 	"github.com/faiface/glhf"
 	"github.com/faiface/mainthread"
 	"github.com/faiface/pixel"

--- a/pixelgl/canvas.go
+++ b/pixelgl/canvas.go
@@ -315,6 +315,10 @@ func (ct *canvasTriangles) draw(tex *glhf.Texture, bounds pixel.Rect) {
 			ct.dst.shader.s.SetUniformAttr(loc, u.Value())
 		}
 
+		if clip, has := ct.ClipRect(); has {
+			gl.Scissor(int32(clip.Min.X), int32(clip.Min.Y), int32(clip.W()), int32(clip.H()))
+		}
+
 		if tex == nil {
 			ct.vs.Begin()
 			ct.vs.Draw()
@@ -327,9 +331,6 @@ func (ct *canvasTriangles) draw(tex *glhf.Texture, bounds pixel.Rect) {
 			}
 
 			ct.vs.Begin()
-			if clip, has := ct.ClipRect(); has {
-				gl.Scissor(int32(clip.Min.X), int32(clip.Min.Y), int32(clip.W()), int32(clip.H()))
-			}
 			ct.vs.Draw()
 			ct.vs.End()
 

--- a/pixelgl/canvas.go
+++ b/pixelgl/canvas.go
@@ -327,6 +327,9 @@ func (ct *canvasTriangles) draw(tex *glhf.Texture, bounds pixel.Rect) {
 			}
 
 			ct.vs.Begin()
+			if clip, has := ct.ClipRect(); has {
+				gl.Scissor(int32(clip.Min.X), int32(clip.Min.Y), int32(clip.W()), int32(clip.H()))
+			}
 			ct.vs.Draw()
 			ct.vs.End()
 

--- a/pixelgl/gltriangles.go
+++ b/pixelgl/gltriangles.go
@@ -16,6 +16,7 @@ type GLTriangles struct {
 	vs     *glhf.VertexSlice
 	data   []float32
 	shader *glhf.Shader
+	clip   pixel.Rect
 }
 
 var (
@@ -212,4 +213,15 @@ func (gt *GLTriangles) Picture(i int) (pic pixel.Vec, intensity float64) {
 	ty := gt.data[i*gt.vs.Stride()+7]
 	intensity = float64(gt.data[i*gt.vs.Stride()+8])
 	return pixel.V(float64(tx), float64(ty)), intensity
+}
+
+// SetClipRect sets the rectangle to scissor the triangles by
+func (gt *GLTriangles) SetClipRect(r pixel.Rect) {
+	gt.clip = r.Norm()
+}
+
+// ClipRect gets the clipping rectangle and returns true if that
+//	rectangle is not the Zero Rectangle
+func (gt *GLTriangles) ClipRect() (pixel.Rect, bool) {
+	return gt.clip, gt.clip.Area() != 0
 }


### PR DESCRIPTION
The Pixel UI project I'm working on needed this support as the triangles provided by imgui were not pre-clipped.