### PR TITLE
Add AnchorPos struct and functions

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -589,22 +589,13 @@ func (anchorPos AnchorPos) String() string {
 }
 
 // AnchorPos returns the position of the given anchor of the Rect.
-func (r *Rect) AnchorPos(anchorPos AnchorPos) Vec {
-	return r.Min.Add(r.Size().ScaledXY(anchorPos.Val))
+func (r Rect) AnchorPos(anchorPos AnchorPos) Vec {
+	return r.Size().ScaledXY(V(0, 0).Sub(anchorPos.Val))
 }
 
-// AnchorTo updates the Rect position to align it on the given anchor.
-func (rect *Rect) AnchorTo(anchorPos AnchorPos) {
-	size := rect.Size()
-	rect.Min = rect.Min.Sub(size.ScaledXY(anchorPos.Val))
-	rect.Max = rect.Max.Sub(size.ScaledXY(anchorPos.Val))
-}
-
-// Aligned moves everything to align the given rectangle on the given anchor position.
-func (m Matrix) Aligned(rect Rect, anchorPos AnchorPos) Matrix {
-	vect := rect.Size().ScaledXY(anchorPos.Val)
-	m[4], m[5] = m[4]-vect.X, m[5]-vect.Y
-	return m
+// AlignedTo returns the rect moved to be aligned on the given anchor.
+func (rect Rect) AlignedTo(anchorPos AnchorPos) Rect {
+	return rect.Moved(rect.AnchorPos(anchorPos))
 }
 
 // Center returns the position of the center of the Rect.

--- a/geometry.go
+++ b/geometry.go
@@ -547,7 +547,55 @@ func (r Rect) Edges() [4]Line {
 	}
 }
 
+// AnchorPos enumerates available anchor positions, such as `Center`, `Top`, `TopRight`, etc.
+type AnchorPos struct{ v Vec }
+
+var (
+	Center      = AnchorPos{V(0.5, 0.5)}
+	Top         = AnchorPos{V(0.5, 1)}
+	TopRight    = AnchorPos{V(1, 1)}
+	Right       = AnchorPos{V(1, 0.5)}
+	BottomRight = AnchorPos{V(1, 0)}
+	Bottom      = AnchorPos{V(0.5, 0)}
+	BottomLeft  = AnchorPos{V(0, 0)}
+	Left        = AnchorPos{V(0, 0.5)}
+	TopLeft     = AnchorPos{V(0, 1)}
+)
+
+// String returns the string representation of an anchor.
+func (anchorPos AnchorPos) String() string {
+	switch anchorPos {
+	case Center:
+		return "Center"
+	case Top:
+		return "Top"
+	case TopRight:
+		return "TopRight"
+	case Right:
+		return "Right"
+	case BottomRight:
+		return "BottomRight"
+	case Bottom:
+		return "Bottom"
+	case BottomLeft:
+		return "BottomLeft"
+	case Left:
+		return "Left"
+	case TopLeft:
+		return "TopLeft"
+	default:
+		return ""
+	}
+}
+
+// AnchorPos returns the position of the given anchor of the Rect.
+func (r *Rect) AnchorPos(anchor AnchorPos) Vec {
+	// func (u Vec) ScaledXY(v Vec) Vec {
+	return r.Min.Add(r.Size().ScaledXY(anchor.v))
+}
+
 // Center returns the position of the center of the Rect.
+// `rect.Center()` is equivalent to `rect.AnchorPos(pixel.AnchorPos.Center)`
 func (r Rect) Center() Vec {
 	return Lerp(r.Min, r.Max, 0.5)
 }

--- a/geometry.go
+++ b/geometry.go
@@ -548,7 +548,7 @@ func (r Rect) Edges() [4]Line {
 }
 
 // AnchorPos enumerates available anchor positions, such as `Center`, `Top`, `TopRight`, etc.
-type AnchorPos struct{ v Vec }
+type AnchorPos struct{ Val Vec }
 
 var (
 	Center      = AnchorPos{V(0.5, 0.5)}
@@ -590,8 +590,14 @@ func (anchorPos AnchorPos) String() string {
 
 // AnchorPos returns the position of the given anchor of the Rect.
 func (r *Rect) AnchorPos(anchor AnchorPos) Vec {
-	// func (u Vec) ScaledXY(v Vec) Vec {
-	return r.Min.Add(r.Size().ScaledXY(anchor.v))
+	return r.Min.Add(r.Size().ScaledXY(anchor.Val))
+}
+
+// AnchorTo updates the Rect position to align it on the given anchor.
+func (r *Rect) AnchorTo(anchor AnchorPos) {
+	size := r.Size()
+	r.Min = r.Min.Sub(size.ScaledXY(anchor.Val))
+	r.Max = r.Max.Sub(size.ScaledXY(anchor.Val))
 }
 
 // Center returns the position of the center of the Rect.

--- a/geometry.go
+++ b/geometry.go
@@ -553,13 +553,13 @@ type Anchor Vec
 var (
 	Center      = Anchor{0.5, 0.5}
 	Top         = Anchor{0.5, 0}
-	TopRight    = Anchor{0,   0}
-	Right       = Anchor{0,   0.5}
-	BottomRight = Anchor{0,   1}
+	TopRight    = Anchor{0, 0}
+	Right       = Anchor{0, 0.5}
+	BottomRight = Anchor{0, 1}
 	Bottom      = Anchor{0.5, 1}
-	BottomLeft  = Anchor{1,   1}
-	Left        = Anchor{1,   0.5}
-	TopLeft     = Anchor{1,   0}
+	BottomLeft  = Anchor{1, 1}
+	Left        = Anchor{1, 0.5}
+	TopLeft     = Anchor{1, 0}
 )
 
 var anchorStrings map[Anchor]string = map[Anchor]string{
@@ -577,6 +577,23 @@ var anchorStrings map[Anchor]string = map[Anchor]string{
 // String returns the string representation of an anchor.
 func (anchor Anchor) String() string {
 	return anchorStrings[anchor]
+}
+
+var oppositeAnchors map[Anchor]Anchor = map[Anchor]Anchor{
+	Center:      Center,
+	Top:         Bottom,
+	Bottom:      Top,
+	Right:       Left,
+	Left:        Right,
+	TopRight:    BottomLeft,
+	BottomLeft:  TopRight,
+	BottomRight: TopLeft,
+	TopLeft:     BottomRight,
+}
+
+// Opposite returns the opposite position of the anchor (ie. Top -> Bottom; BottomLeft -> TopRight, etc.).
+func (anchor Anchor) Opposite() Anchor {
+	return oppositeAnchors[anchor]
 }
 
 // AnchorPos returns the relative position of the given anchor.

--- a/geometry.go
+++ b/geometry.go
@@ -589,15 +589,22 @@ func (anchorPos AnchorPos) String() string {
 }
 
 // AnchorPos returns the position of the given anchor of the Rect.
-func (r *Rect) AnchorPos(anchor AnchorPos) Vec {
-	return r.Min.Add(r.Size().ScaledXY(anchor.Val))
+func (r *Rect) AnchorPos(anchorPos AnchorPos) Vec {
+	return r.Min.Add(r.Size().ScaledXY(anchorPos.Val))
 }
 
 // AnchorTo updates the Rect position to align it on the given anchor.
-func (r *Rect) AnchorTo(anchor AnchorPos) {
-	size := r.Size()
-	r.Min = r.Min.Sub(size.ScaledXY(anchor.Val))
-	r.Max = r.Max.Sub(size.ScaledXY(anchor.Val))
+func (rect *Rect) AnchorTo(anchorPos AnchorPos) {
+	size := rect.Size()
+	rect.Min = rect.Min.Sub(size.ScaledXY(anchorPos.Val))
+	rect.Max = rect.Max.Sub(size.ScaledXY(anchorPos.Val))
+}
+
+// Aligned moves everything to align the given rectangle on the given anchor position.
+func (m Matrix) Aligned(rect Rect, anchorPos AnchorPos) Matrix {
+	vect := rect.Size().ScaledXY(anchorPos.Val)
+	m[4], m[5] = m[4]-vect.X, m[5]-vect.Y
+	return m
 }
 
 // Center returns the position of the center of the Rect.

--- a/geometry.go
+++ b/geometry.go
@@ -547,59 +547,59 @@ func (r Rect) Edges() [4]Line {
 	}
 }
 
-// AnchorPos enumerates available anchor positions, such as `Center`, `Top`, `TopRight`, etc.
-type AnchorPos struct{ Val Vec }
+// Anchor is a vector used to define anchors, such as `Center`, `Top`, `TopRight`, etc.
+type Anchor Vec
 
 var (
-	Center      = AnchorPos{V(0.5, 0.5)}
-	Top         = AnchorPos{V(0.5, 1)}
-	TopRight    = AnchorPos{V(1, 1)}
-	Right       = AnchorPos{V(1, 0.5)}
-	BottomRight = AnchorPos{V(1, 0)}
-	Bottom      = AnchorPos{V(0.5, 0)}
-	BottomLeft  = AnchorPos{V(0, 0)}
-	Left        = AnchorPos{V(0, 0.5)}
-	TopLeft     = AnchorPos{V(0, 1)}
+	Center      = Anchor{0.5, 0.5}
+	Top         = Anchor{0.5, 1}
+	TopRight    = Anchor{1,   1}
+	Right       = Anchor{1,   0.5}
+	BottomRight = Anchor{1,   0}
+	Bottom      = Anchor{0.5, 0}
+	BottomLeft  = Anchor{0,   0}
+	Left        = Anchor{0,   0.5}
+	TopLeft     = Anchor{0,   1}
 )
 
 // String returns the string representation of an anchor.
-func (anchorPos AnchorPos) String() string {
-	switch anchorPos {
+func (anchor Anchor) String() string {
+	switch anchor {
 	case Center:
-		return "Center"
+		return "center"
 	case Top:
-		return "Top"
+		return "top"
 	case TopRight:
-		return "TopRight"
+		return "top-right"
 	case Right:
-		return "Right"
+		return "right"
 	case BottomRight:
-		return "BottomRight"
+		return "bottom-right"
 	case Bottom:
-		return "Bottom"
+		return "bottom"
 	case BottomLeft:
-		return "BottomLeft"
+		return "bottom-left"
 	case Left:
-		return "Left"
+		return "left"
 	case TopLeft:
-		return "TopLeft"
+		return "top-left"
 	default:
 		return ""
 	}
 }
 
-// AnchorPos returns the position of the given anchor of the Rect.
-func (r Rect) AnchorPos(anchorPos AnchorPos) Vec {
-	return r.Size().ScaledXY(V(0, 0).Sub(anchorPos.Val))
+// AnchorPos returns the relative position of the given anchor.
+func (r Rect) AnchorPos(anchor Anchor) Vec {
+	return r.Size().ScaledXY(V(0, 0).Sub(Vec(anchor)))
 }
 
-// AlignedTo returns the rect moved to be aligned on the given anchor.
-func (rect Rect) AlignedTo(anchorPos AnchorPos) Rect {
-	return rect.Moved(rect.AnchorPos(anchorPos))
+// AlignedTo returns the rect moved by the given anchor.
+func (rect Rect) AlignedTo(anchor Anchor) Rect {
+	return rect.Moved(rect.AnchorPos(anchor))
 }
 
 // Center returns the position of the center of the Rect.
-// `rect.Center()` is equivalent to `rect.AnchorPos(pixel.AnchorPos.Center)`
+// `rect.Center()` is equivalent to `rect.Anchor(pixel.Anchor.Center)`
 func (r Rect) Center() Vec {
 	return Lerp(r.Min, r.Max, 0.5)
 }

--- a/geometry.go
+++ b/geometry.go
@@ -552,40 +552,31 @@ type Anchor Vec
 
 var (
 	Center      = Anchor{0.5, 0.5}
-	Top         = Anchor{0.5, 1}
-	TopRight    = Anchor{1,   1}
-	Right       = Anchor{1,   0.5}
-	BottomRight = Anchor{1,   0}
-	Bottom      = Anchor{0.5, 0}
-	BottomLeft  = Anchor{0,   0}
-	Left        = Anchor{0,   0.5}
-	TopLeft     = Anchor{0,   1}
+	Top         = Anchor{0.5, 0}
+	TopRight    = Anchor{0,   0}
+	Right       = Anchor{0,   0.5}
+	BottomRight = Anchor{0,   1}
+	Bottom      = Anchor{0.5, 1}
+	BottomLeft  = Anchor{1,   1}
+	Left        = Anchor{1,   0.5}
+	TopLeft     = Anchor{1,   0}
 )
+
+var anchorStrings map[Anchor]string = map[Anchor]string{
+	Center:      "center",
+	Top:         "top",
+	TopRight:    "top-right",
+	Right:       "right",
+	BottomRight: "bottom-right",
+	Bottom:      "bottom",
+	BottomLeft:  "bottom-left",
+	Left:        "left",
+	TopLeft:     "top-left",
+}
 
 // String returns the string representation of an anchor.
 func (anchor Anchor) String() string {
-	switch anchor {
-	case Center:
-		return "center"
-	case Top:
-		return "top"
-	case TopRight:
-		return "top-right"
-	case Right:
-		return "right"
-	case BottomRight:
-		return "bottom-right"
-	case Bottom:
-		return "bottom"
-	case BottomLeft:
-		return "bottom-left"
-	case Left:
-		return "left"
-	case TopLeft:
-		return "top-left"
-	default:
-		return ""
-	}
+	return anchorStrings[anchor]
 }
 
 // AnchorPos returns the relative position of the given anchor.

--- a/text/text.go
+++ b/text/text.go
@@ -101,6 +101,7 @@ type Text struct {
 	trans  pixel.TrianglesData
 	transD pixel.Drawer
 	dirty  bool
+	anchor pixel.Anchor
 }
 
 // New creates a new Text capable of drawing runes contained in the provided Atlas. Orig and Dot
@@ -182,6 +183,12 @@ func (txt *Text) BoundsOf(s string) pixel.Rect {
 	return bounds
 }
 
+// AlignedTo returns the text moved by the given anchor.
+func (txt *Text) AlignedTo(anchor pixel.Anchor) *Text {
+	txt.anchor = anchor
+	return txt
+}
+
 // Clear removes all written text from the Text. The Dot field is reset to Orig.
 func (txt *Text) Clear() {
 	txt.prevR = -1
@@ -244,6 +251,10 @@ func (txt *Text) DrawColorMask(t pixel.Target, matrix pixel.Matrix, mask color.C
 		txt.mat = matrix
 		txt.dirty = true
 	}
+
+	offset := txt.Bounds().AnchorPos(txt.anchor)
+	txt.mat = pixel.IM.Moved(offset).Chained(txt.mat)
+
 	if mask == nil {
 		mask = pixel.Alpha(1)
 	}

--- a/text/text.go
+++ b/text/text.go
@@ -252,7 +252,7 @@ func (txt *Text) DrawColorMask(t pixel.Target, matrix pixel.Matrix, mask color.C
 		txt.dirty = true
 	}
 
-	offset := txt.Bounds().AnchorPos(txt.anchor)
+	offset := txt.Orig.Sub(txt.Bounds().Max.Add(txt.Bounds().AnchorPos(txt.anchor.Opposite())))
 	txt.mat = pixel.IM.Moved(offset).Chained(txt.mat)
 
 	if mask == nil {


### PR DESCRIPTION
This PR adds the concept of *anchors* to align elements.

It adds:
- `type Anchor`: *a vector used to define anchors, such as `Center`, `Top`, `TopRight`, etc.*;
- `func (Anchor) String() string`: *returns the string representation of an anchor.*;
- `func (*Rect) AnchorPos(anchor Anchor) Vec`: *returns the ~~absolute~~ position of the given anchor of the Rect.*;
- ~~edit: `func (*Rect) AnchorTo(Anchor)`: *updates the Rect position to align it on the given anchor.*~~
- edit: `func (Rect) AlignedTo(Anchor) Rect`: *returns the rect moved to be aligned on the given anchor.*
- ~~edit: `func (Matrix) Aligned(Rect, anchorPos AnchorPos) Matrix`: *moves everything to align the given rectangle on the given anchor position.*~~
- edit: `func (*Text) AlignedTo(pixel.Anchor) *Text`: *returns the text moved by the given anchor.*
- edit: `func (Anchor) Opposite() Anchor`: *returns the opposite position of the anchor (ie. Top -> Bottom; BottomLeft -> TopRight, etc.).*

## Example code

edit: Update with last modifications.

```go
package main

import (
	"image/color"
	"fmt"
	"github.com/faiface/pixel"
	"github.com/faiface/pixel/imdraw"
	"github.com/faiface/pixel/pixelgl"
	"golang.org/x/image/colornames"
	"github.com/faiface/pixel/text"
	"golang.org/x/image/font/basicfont"
)

const (
	winWidth   float64 = 600
	winHeight  float64 = 450
	padding    float64 = 170
	rectWidth, rectHeight float64 = 90, 90
	minX, minY float64 = padding, padding
	maxX, maxY float64 = winWidth - padding, winHeight - padding
	cX, cY     float64 = winWidth/2, winHeight/2
)

var dotsPos map[pixel.Anchor]pixel.Vec = map[pixel.Anchor]pixel.Vec{
	pixel.Center: pixel.V(cX, cY),
	pixel.Top: pixel.V(cX, maxY),
	pixel.TopRight: pixel.V(maxX, maxY),
	pixel.Right: pixel.V(maxX, cY),
	pixel.BottomRight: pixel.V(maxX, minY),
	pixel.Bottom: pixel.V(cX, minY),
	pixel.BottomLeft: pixel.V(minX, minY),
	pixel.Left: pixel.V(minX, cY),
	pixel.TopLeft: pixel.V(minX, maxY),
}
func drawRectanglesAndDots(win *pixelgl.Window) {
	imd := imdraw.New(nil)
	for anchor, vect := range dotsPos {
		rect := pixel.R(vect.X, vect.Y, vect.X + rectWidth, vect.Y + rectHeight).AlignedTo(anchor)
		drawRect(imd, rect, colornames.Gray)
		drawDot(imd, vect, colornames.Red)
	}
	imd.Draw(win)
}

func drawLabels(win *pixelgl.Window) {
	const scale float64 = 2
	basicAtlas := text.NewAtlas(basicfont.Face7x13, text.ASCII)
	for anchor, vect := range dotsPos {
		basicTxt := text.New(vect, basicAtlas)
		basicTxt.Color = colornames.Yellow
		fmt.Fprintln(basicTxt, anchor.String())
		basicTxt.AlignedTo(anchor).Draw(win, pixel.IM.Scaled(basicTxt.Orig, scale))
	}
}

func drawRect(imd *imdraw.IMDraw, rect pixel.Rect, color color.Color) {
	imd.Color = color
	imd.Push(rect.Min, rect.Max)
	imd.Rectangle(0)
}

func drawDot(imd *imdraw.IMDraw, vect pixel.Vec, color color.Color) {
	imd.Color = color
	imd.Push(vect)
	imd.Ellipse(pixel.V(3, 3), 0)
}

func run() {
	cfg := pixelgl.WindowConfig{
		Title:  "AnchorPos examples",
		Bounds: pixel.R(0, 0, winWidth, winHeight),
		VSync:  true,
	}
	win, err := pixelgl.NewWindow(cfg)
	if err != nil {
		panic(err)
	}

	win.Clear(colornames.Lightgray)
	drawRectanglesAndDots(win)
	drawLabels(win)

	for !win.Closed() {
		win.Update()
	}
}

func main() {
	pixelgl.Run(run)
}
```

## Result

![image](https://user-images.githubusercontent.com/1665542/90957283-de0a6900-e48c-11ea-9b38-1bd780a2debb.png)

## More to come

edit: done!

~~The modifications added in this first commit are required for other functions that I plan to add as well in this PR, named `AnchorTo`:~~

~~- `func (r *Rect) AnchorTo(anchor AnchorPos)`: updates the Rect position to align it on the given anchor.~~
~~- `func (r *Text) AnchorTo(anchor AnchorPos)`: updates the Text position to align it on the given anchor.~~
~~- etc. At this point it's easy to add implementation for many other objects (Circle, Image, etc.)~~

~~Example usage:~~

```go
basicTxt := text.New(vect, basicAtlas)
basicTxt.AnchorTo(AnchorPos.Center)
```

~~Here, `basicTxt` will be centered relative to the `vect` position. With `AnchorPos.Left`, it will be centered verticaly but not horizontally, etc.~~

~~This is helpful to position and align elements.~~

~~I would like to get your feedback before to continue. ;)~~