### PR TITLE
Use slice for range in Drawer.Dirty(), to improve performance

### DIFF
--- a/drawer.go
+++ b/drawer.go
@@ -24,8 +24,9 @@ type Drawer struct {
 	Triangles Triangles
 	Picture   Picture
 
-	targets map[Target]*drawerTarget
-	inited  bool
+	targets    map[Target]*drawerTarget
+	allTargets []*drawerTarget
+	inited     bool
 }
 
 type drawerTarget struct {
@@ -46,7 +47,7 @@ func (d *Drawer) lazyInit() {
 func (d *Drawer) Dirty() {
 	d.lazyInit()
 
-	for _, t := range d.targets {
+	for _, t := range d.allTargets {
 		t.clean = false
 	}
 }
@@ -68,6 +69,7 @@ func (d *Drawer) Draw(t Target) {
 			pics: make(map[Picture]TargetPicture),
 		}
 		d.targets[t] = dt
+		d.allTargets = append(d.allTargets, dt)
 	}
 
 	if dt.tris == nil {


### PR DESCRIPTION
Using `pprof` to profile a game prototype where I was seeing some stuttering, I found I was getting a bottleneck iterating over the map `d.targets` within `Drawer.Dirty`, with the time mostly being taken up by `runtime.mapiternext`. Since it's looping over all the values, I thought I'd try indexing those values with a slice instead. From my quick measurements, it cleared up the problem right away (from taking up ~5s out of 30 seconds sampled, to ~.3s).

The changes here are pretty simple. I'm not sure if you'd like more evidence/rigor in demonstrating the perf improvement, but I think that for a large enough cardinality the perf benefits of looping over a slice as opposed to a map are well known (see e.g. "Test 4" [here](https://boltandnuts.wordpress.com/2017/11/20/go-slice-vs-maps/)). Obviously there's some additional memory used by the slice, but the trade-off seems good to me.

I'm happy to tweak the naming or whatever if you have something you'd prefer. Let me know and I'm happy to cooperate on refinements.