### PR TITLE
feat(Vec): add squared len method

### DIFF
--- a/vector.go
+++ b/vector.go
@@ -128,6 +128,11 @@ func (u Vec) Len() float64 {
 	return math.Hypot(u.X, u.Y)
 }
 
+// SqLen returns the squared length of the vector u (faster to compute than Len).
+func (u Vec) SqLen() float64 {
+	return u.X*u.X + u.Y*u.Y
+}
+
 // Angle returns the angle between the vector u and the x-axis. The result is in range [-Pi, Pi].
 func (u Vec) Angle() float64 {
 	return math.Atan2(u.Y, u.X)


### PR DESCRIPTION
The Vec struct already has a `Len` method, but the squared root could be a performance hit.
When we just want to compare the length of two Vec, it is better to use the squared length.
I suggest adding this in vector.go, under the `Len` method:
```go
// SqLen returns the squared length of the vector u (faster to compute than Len).
func (u Vec) SqLen() float64 {
	return u.X*u.X + u.Y*u.Y
}
```

I love your work on this repo BTW, it's great and simple to use!