### PR TITLE
Define bounds on both circle and rect for use with interfaces

### DIFF
--- a/circle.go
+++ b/circle.go
@@ -48,6 +48,14 @@ func (c Circle) Area() float64 {
 	return math.Pi * math.Pow(c.Radius, 2)
 }
 
+// Bounds returns the bounding box for the circle
+func (c Circle) Bounds() Rect {
+	return Rect{
+		Min: V(c.Center.X-c.Radius, c.Center.Y-c.Radius),
+		Max: V(c.Center.X+c.Radius, c.Center.Y+c.Radius),
+	}
+}
+
 // Moved returns the Circle moved by the given vector delta.
 func (c Circle) Moved(delta Vec) Circle {
 	return Circle{

--- a/rectangle.go
+++ b/rectangle.go
@@ -70,6 +70,11 @@ func (r Rect) Area() float64 {
 	return r.W() * r.H()
 }
 
+// Bounds returns the bounding box for the rect (itself)
+func (r Rect) Bounds() Rect {
+	return r
+}
+
 // Edges will return the four lines which make up the edges of the rectangle.
 func (r Rect) Edges() [4]Line {
 	corners := r.Vertices()


### PR DESCRIPTION
In my project I have a basic Shape interface defined as
```
type Shape interface {
	Area() float64
	Bounds() pixel.Rect
	Contains(point pixel.Vec) bool
}
```

It would be super useful if the pixel shapes matched this interface. Rect of course would just return itself.

Working on a physics engine built on top of pixel (🤫), and I'm trying to keep to native pixel structs as much as possible. This would give me a lot of flexibility in working with them.

Not sure if it makes sense to add the interface itself to pixel or not, but I would certainly use it.